### PR TITLE
fix: harden facebook sdk initialization on android

### DIFF
--- a/android/src/main/java/com/dabchy/plugins/facebookevents/FacebookEvents.java
+++ b/android/src/main/java/com/dabchy/plugins/facebookevents/FacebookEvents.java
@@ -1,22 +1,32 @@
 package com.dabchy.plugins.facebookevents;
 
+import android.content.Context;
 import android.os.Bundle;
 import com.facebook.appevents.AppEventsLogger;
 import com.getcapacitor.JSObject;
+import com.getcapacitor.Logger;
 import com.getcapacitor.Plugin;
 import java.util.Iterator;
 
 public class FacebookEvents {
 
-    private final AppEventsLogger logger;
+    private static final String LOG_TAG = "FacebookEvents";
+
+    private final Plugin plugin;
+    private AppEventsLogger logger;
 
     public FacebookEvents(Plugin plugin) {
-        logger = AppEventsLogger.newLogger(plugin.getContext());
+        this.plugin = plugin;
+    }
+
+    public synchronized void reset() {
+        logger = null;
     }
 
     public void logEvent(String event, JSObject params) {
+        AppEventsLogger logger = getLogger();
         if (logger == null) {
-            // Logger not initialized, handle this scenario appropriately
+            Logger.warn(LOG_TAG, "Unable to log event \"" + event + "\" because no valid context is available for the Facebook SDK.");
             return;
         }
 
@@ -24,12 +34,37 @@ public class FacebookEvents {
             Bundle parameters = new Bundle();
             for (Iterator<String> it = params.keys(); it.hasNext();) {
                 String key = it.next();
-                parameters.putString(key, params.getString(key));
+                String value = params.getString(key);
+                if (value != null) {
+                    parameters.putString(key, value);
+                }
             }
             logger.logEvent(event, parameters);
         } else {
-            // Log the event without parameters if params is null or empty
             logger.logEvent(event);
         }
+    }
+
+    private synchronized AppEventsLogger getLogger() {
+        if (logger != null) {
+            return logger;
+        }
+
+        Context context = plugin.getContext();
+        if (context == null) {
+            context = plugin.getActivity();
+        }
+
+        if (context == null) {
+            return null;
+        }
+
+        Context appContext = context.getApplicationContext();
+        if (appContext != null) {
+            context = appContext;
+        }
+
+        logger = AppEventsLogger.newLogger(context);
+        return logger;
     }
 }

--- a/android/src/main/java/com/dabchy/plugins/facebookevents/FacebookEventsPlugin.java
+++ b/android/src/main/java/com/dabchy/plugins/facebookevents/FacebookEventsPlugin.java
@@ -1,6 +1,13 @@
 package com.dabchy.plugins.facebookevents;
 
+import android.app.Application;
+import android.content.Context;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import com.facebook.FacebookSdk;
+import com.facebook.appevents.AppEventsLogger;
 import com.getcapacitor.JSObject;
+import com.getcapacitor.Logger;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
@@ -9,28 +16,122 @@ import com.getcapacitor.annotation.CapacitorPlugin;
 @CapacitorPlugin(name = "FacebookEvents")
 public class FacebookEventsPlugin extends Plugin {
 
+    private static final String LOG_TAG = "FacebookEventsPlugin";
+
     private FacebookEvents facebookEvents;
 
     @Override
     public void load() {
         facebookEvents = new FacebookEvents(this);
+        initializeFacebookSdk();
     }
 
     @Override
     protected void handleOnStart() {
         super.handleOnStart();
+        Application application = resolveApplication();
+
+        if (application == null) {
+            Logger.warn(LOG_TAG, "Unable to activate Facebook App Events because the application reference is null.");
+            return;
+        }
+
+        initializeFacebookSdk();
+        AppEventsLogger.activateApp(application);
+    }
+
+    @Override
+    protected void handleOnStop() {
+        super.handleOnStop();
+        Application application = resolveApplication();
+
+        if (application != null) {
+            AppEventsLogger.deactivateApp(application);
+        }
+    }
+
+    @Override
+    protected void handleOnDestroy() {
+        super.handleOnDestroy();
+        if (facebookEvents != null) {
+            facebookEvents.reset();
+        }
     }
 
     @PluginMethod
     public void setAdvertiserTrackingEnabled(PluginCall call) {
+        Boolean enabled = call.getBoolean("enabled");
+
+        if (enabled == null) {
+            call.reject("Missing enabled argument");
+            return;
+        }
+
+        initializeFacebookSdk();
+        FacebookSdk.setAdvertiserIDCollectionEnabled(enabled);
+        FacebookSdk.setAutoLogAppEventsEnabled(enabled);
+        FacebookSdk.setAutoInitEnabled(enabled);
         call.resolve();
     }
 
     @PluginMethod
     public void logEvent(PluginCall call) {
         String event = call.getString("event");
+        if (event == null || event.trim().isEmpty()) {
+            call.reject("Missing event argument");
+            return;
+        }
+
         JSObject params = call.getObject("params", new JSObject());
+        initializeFacebookSdk();
+
+        if (facebookEvents == null) {
+            facebookEvents = new FacebookEvents(this);
+        }
+
         facebookEvents.logEvent(event, params);
         call.resolve();
+    }
+
+    private void initializeFacebookSdk() {
+        Application application = resolveApplication();
+        if (application == null) {
+            Logger.warn(LOG_TAG, "Unable to initialize the Facebook SDK because the application reference is null.");
+            return;
+        }
+
+        Context appContext = application.getApplicationContext();
+        if (appContext == null) {
+            Logger.warn(LOG_TAG, "Unable to initialize the Facebook SDK because the application context is null.");
+            return;
+        }
+
+        synchronized (FacebookEventsPlugin.class) {
+            if (!FacebookSdk.isInitialized()) {
+                FacebookSdk.sdkInitialize(appContext);
+            }
+
+            FacebookSdk.setAutoInitEnabled(true);
+            FacebookSdk.setAutoLogAppEventsEnabled(true);
+            FacebookSdk.setAdvertiserIDCollectionEnabled(true);
+        }
+    }
+
+    @Nullable
+    private Application resolveApplication() {
+        AppCompatActivity activity = getActivity();
+        if (activity != null) {
+            return activity.getApplication();
+        }
+
+        Context context = getContext();
+        if (context != null) {
+            Context appContext = context.getApplicationContext();
+            if (appContext instanceof Application) {
+                return (Application) appContext;
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
- ensure the Facebook SDK is initialized with the application context before logging events or toggling advertiser tracking
- add lifecycle hooks and safeguards so Facebook App Events activation uses a valid application reference and resets stale loggers
- validate plugin inputs and reuse a lazily created logger bound to the application context to prevent silent failures on Android

## Testing
- npm run lint *(fails: existing Prettier formatting issues in example and web sources)*

------
https://chatgpt.com/codex/tasks/task_b_68f22ecb9bec8321a78f85cc66153a7d